### PR TITLE
Chesca

### DIFF
--- a/Controller/Css.php
+++ b/Controller/Css.php
@@ -9,20 +9,36 @@ class Css {
 	
 	protected $_config;
 	protected $_lessBuilder;
+	protected $_scssBuilder;
 	
 	public function __construct(
 		\Of\Config $Config,
-		\Of\Less\Builder $LessBuilder
+		\Of\Less\Builder $LessBuilder,
+		\ScssPhp\ScssPhp\Compiler $ScssBuilder
 	){
 		
 		$this->_config = $Config;
 		$this->_lessBuilder = $LessBuilder;
+		$this->_scssBuilder = $ScssBuilder;
 	}
 	
 	public function run($file){
-		$css = $this->_lessBuilder
-		->setConfig($this->_config)
-		->build($file);
+
+		$css = null;
+
+		$fArray = explode('.', $file);
+		if(in_array('scss', $fArray)){
+			$css = $this->_scssBuilder->compileString('
+				$color: #abc;
+				div { color: lighten($color, 20%); }
+			')->getCss();
+		}
+		else {
+			$css = $this->_lessBuilder
+			->setConfig($this->_config)
+			->build($file);
+		}
+
 
 		if($css){
 			echo header("Content-type: text/css", true);

--- a/Controller/Css.php
+++ b/Controller/Css.php
@@ -14,7 +14,7 @@ class Css {
 	public function __construct(
 		\Of\Config $Config,
 		\Of\Less\Builder $LessBuilder,
-		\ScssPhp\ScssPhp\Compiler $ScssBuilder
+		\Of\File\ScssBuilder $ScssBuilder
 	){
 		
 		$this->_config = $Config;
@@ -28,10 +28,7 @@ class Css {
 
 		$fArray = explode('.', $file);
 		if(in_array('scss', $fArray)){
-			$css = $this->_scssBuilder->compileString('
-				$color: #abc;
-				div { color: lighten($color, 20%); }
-			')->getCss();
+			$css = $this->_scssBuilder->setConfig($this->_config)->build($file);
 		}
 		else {
 			$css = $this->_lessBuilder

--- a/Controller/Sys/SystemInstallOpoinkbmodule.php
+++ b/Controller/Sys/SystemInstallOpoinkbmodule.php
@@ -25,36 +25,42 @@ class SystemInstallOpoinkbmodule extends Sys {
 			try {
 				$target = ROOT.DS.'vendor'.DS.'opoink'.DS.'bmodule';
 				$dst = ROOT.DS.'App'.DS.'Ext'.DS.'Opoink'.DS.'Bmodule';
-				if(is_dir($target) && !is_dir($dst)){
-					$dirmanager = $this->_di->get('Of\File\Dirmanager');
-					$dirmanager->copyDir($target, $dst);
-
-					if(is_dir($dst)){
-						$modManager = $this->_di->get('\Of\ModManager\Module');
-
-						$availableModules = [
-							'Opoink_Bmodule'
-						];
-						$installed = $modManager->setDi($this->_di)->installModule($availableModules);
-						$installedCount = count($installed);
-
-						if($installedCount == 1){
-							$response['error'] = 0;
-							$response['message'] = 'Opoink/Bmodule successfully installed';
+				if(!is_dir($target)){
+					header("HTTP/1.0 406 Not Acceptable");
+					echo 'Opoink/Bmodule not found';
+					die;
+				} else {
+					if(is_dir($target) && !is_dir($dst)){
+						$dirmanager = $this->_di->get('Of\File\Dirmanager');
+						$dirmanager->copyDir($target, $dst);
+	
+						if(is_dir($dst)){
+							$modManager = $this->_di->get('\Of\ModManager\Module');
+	
+							$availableModules = [
+								'Opoink_Bmodule'
+							];
+							$installed = $modManager->setDi($this->_di)->installModule($availableModules);
+							$installedCount = count($installed);
+	
+							if($installedCount == 1){
+								$response['error'] = 0;
+								$response['message'] = 'Opoink/Bmodule successfully installed';
+							} else {
+								header("HTTP/1.0 406 Not Acceptable");
+								echo 'Failed to install Opoink/Bmodule';
+								die;
+							}
 						} else {
 							header("HTTP/1.0 406 Not Acceptable");
-							echo 'Failed to install Opoink/Bmodule';
+							echo 'Failed to copy Opoink/Bmodule to App/Ext directory';
 							die;
 						}
 					} else {
 						header("HTTP/1.0 406 Not Acceptable");
-						echo 'Failed to copy Opoink/Bmodule to App/Ext directory';
+						echo 'Opoink/Bmodule already installed';
 						die;
 					}
-				} else {
-					header("HTTP/1.0 406 Not Acceptable");
-					echo 'Opoink/Bmodule already installed';
-					die;
 				}
 			} catch (\Exception $e) {
 				header("HTTP/1.0 400 Bad Request");

--- a/File/ScssBuilder.php
+++ b/File/ScssBuilder.php
@@ -1,0 +1,83 @@
+<?php
+/**
+* Copyright 2018 Opoink Framework (http://opoink.com/)
+* Licensed under MIT, see LICENSE.md
+*/
+namespace Of\File;
+
+use ScssPhp\ScssPhp\Compiler;
+
+/* https://www.minifier.org/ */
+use MatthiasMullie\Minify;
+
+class ScssBuilder extends \Of\Less\Builder {
+
+	protected $filePaths = [];
+	protected $_config;
+	
+
+	public function setConfig($Config){
+		$this->_config = $Config;
+		return $this;
+	}
+
+	public function build($file) {
+		$requestUri = $_SERVER['REQUEST_URI'];
+		$uri = explode('?', $requestUri);
+
+		$cssString = '';
+		if($uri[0] != '' || $uri[0] != null){
+
+			$_file = str_replace('.scss.css', '.scss', $file);
+
+			$path = str_replace('/'.$file, '', $uri[0]);
+			$path = strtolower(str_replace('/', DS, $path));
+
+			$path =  $this->getRealPath($path);
+
+			$_scssFiles = [];
+			foreach($this->_config->getConfig('modules') as $vendor => $modules) {
+				foreach($modules as $module){
+					$viewDir = ROOT.DS.'App'.DS.'Ext'.DS.$vendor.DS.$module.DS.'View'.DS;
+					$scssFile = ltrim(strtolower($path.DS.$_file), DS);
+
+					$targetScssFile = $viewDir . $scssFile;
+
+					if(file_exists($targetScssFile)){
+						$_scssFiles[] = $targetScssFile;
+					}
+				}
+			}
+
+			foreach ($_scssFiles as $key => $scssFile) {
+				$compiler = new Compiler();
+				$compiler->setImportPaths(dirname($scssFile));
+
+				$scssString = file_get_contents($scssFile);
+				$cssString .= $compiler->compileString($scssString)->getCss();
+			}
+
+			if($this->_config->getConfig('mode') == \Of\Constants::MODE_PROD){
+				$minifier = new Minify\CSS();
+				$minifier->add($cssString);
+
+				$deploy = ROOT.DS.'public'.DS.'deploy';
+				if(file_exists(ROOT.DS.'public'.DS.'generation.php')){
+					$deploy .= include(ROOT.DS.'public'.DS.'generation.php');
+				}
+	
+				$publicCssDir = $deploy . DS . ltrim($path, DS);
+				$destinationFile = $publicCssDir.DS.$file;
+
+				$this->makeDir($publicCssDir);
+				return $minifier->minify($destinationFile);
+			} else {
+				return $cssString;
+			}
+		}
+		else {
+			return $cssString;
+		}
+	}
+}
+?>

--- a/File/Xmltohtml.php
+++ b/File/Xmltohtml.php
@@ -369,9 +369,14 @@ class Xmltohtml {
 		return false;
 	}
 	
-	/*
-	*	create css tag
-	*/
+	/**
+	 * create css html element
+	 * vlaid xml attributes are 
+	 *  - src: the src of less or scss file
+	 *  - type: less or scss the default type is less, if type is not set then less parser will be used
+	 *  - external: if the xml has attribute external then the src should be a valid css link and type is ignored
+	 *  - media
+	 */
 	protected function createCssTag($node){
 		if(!$node->hasAttribute('src')){
 			$error = 'CSS src is required from xml ID: ' . $node->getAttribute('xml:id');
@@ -385,6 +390,9 @@ class Xmltohtml {
 		} else {
 			$deployTIme = 'deploy'.$this->getDeployTime();
 			$src = $this->_url->getUrl('/public/'.$deployTIme.'/'.ltrim($node->getAttribute('src'), '/'));
+			if($node->hasAttribute('type')){
+				$src .= '.' . $node->getAttribute('type');
+			}
 			$src .= '.css';
 			$tag .= ' href="'.$src.'" ';
 		}

--- a/change.log
+++ b/change.log
@@ -1,5 +1,5 @@
 03-03-2022 -- Throw an error during installation of Opoink/Bmodule if file not found currenty the Opoink/Bmodule is under construction
 03-03-2022 -- We will now add support for SCSS using "scssphp/scssphp": "^1.10.1" now added in composer.json file
 03-03-2022 -- for xml layout, a new attribute "type" is added the value should be "less" or "scss" since Opoink use less css first, "less" is the default if type is not defined
-03-03-2022 -- ScssBuilder class is add to parse scss files in all installed module.
+03-03-2022 -- ScssBuilder class is added to parse scss files in all installed module.
 03-03-2022 -- if scss is used as type "<css src='css/admin/<filesname>' type='scss' media='all' />" then opoink will look in all installed modules for the files  <filesname>.scss and compile it into 1 css result.

--- a/change.log
+++ b/change.log
@@ -1,0 +1,3 @@
+03-03-2022 -- Throw an error during installation of Opoink/Bmodule if file not found currenty the Opoink/Bmodule is under construction
+03-03-2022 -- We will now add support for SCSS using "scssphp/scssphp": "^1.10.1" now added in composer.json file
+03-03-2022 -- for xml layout, a new attribute "type" is added the value should be "less" or "scss"

--- a/change.log
+++ b/change.log
@@ -1,3 +1,5 @@
 03-03-2022 -- Throw an error during installation of Opoink/Bmodule if file not found currenty the Opoink/Bmodule is under construction
 03-03-2022 -- We will now add support for SCSS using "scssphp/scssphp": "^1.10.1" now added in composer.json file
-03-03-2022 -- for xml layout, a new attribute "type" is added the value should be "less" or "scss"
+03-03-2022 -- for xml layout, a new attribute "type" is added the value should be "less" or "scss" since Opoink use less css first, "less" is the default if type is not defined
+03-03-2022 -- ScssBuilder class is add to parse scss files in all installed module.
+03-03-2022 -- if scss is used as type "<css src='css/admin/<filesname>' type='scss' media='all' />" then opoink will look in all installed modules for the files  <filesname>.scss and compile it into 1 css result.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "opoink/router": ">=1.0.0",
         "opoink/template": ">1.0.1",
         "opoink/cli": ">=1.0.0",
-		"phpmailer/phpmailer": "^6.5"
+		"phpmailer/phpmailer": "^6.5",
+		"scssphp/scssphp": "^1.10.1"
     },
     "authors": [
         {


### PR DESCRIPTION
03-03-2022 -- Throw an error during installation of Opoink/Bmodule if file not found currenty the Opoink/Bmodule is under construction
03-03-2022 -- We will now add support for SCSS using "scssphp/scssphp": "^1.10.1" now added in composer.json file
03-03-2022 -- for xml layout, a new attribute "type" is added the value should be "less" or "scss" since Opoink use less css first, "less" is the default if type is not defined
03-03-2022 -- ScssBuilder class is added to parse scss files in all installed module.
03-03-2022 -- if scss is used as type "<css src='css/admin/<filesname>' type='scss' media='all' />" then opoink will look in all installed modules for the files  <filesname>.scss and compile it into 1 css result.