### PR TITLE
Chesca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+Global Functions
+- opoink_renderError() add condition to check if the request is comming from CLI then make the mode production to log the error instead of redering html
+
 Entity
 - \Of\Database\Entity::getFinalResponse() if the current page is greater than the total page then use total page as the current page
+- \Of\Database\Entity::getFinalResponse() Fix variable $data to handle a null result
 
 PHP 8.2 Deprecation
 - Fix Dynamic variable deprecated issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 Global Functions
-- opoink_renderError() add condition to check if the request is comming from CLI then make the mode production to log the error instead of redering html
+- opoink_renderError() add a condition to check if the request is coming from CLI then make the mode production to log the error instead of rendering HTML
 
 Entity
 - \Of\Database\Entity::getFinalResponse() if the current page is greater than the total page then use total page as the current page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Entity
+- \Of\Database\Entity::getFinalResponse() if the current page is greater than the total page then use total page as the current page
+
 PHP 8.2 Deprecation
 - Fix Dynamic variable deprecated issue
 

--- a/Controller/Sys/SystemModuleIndex.php
+++ b/Controller/Sys/SystemModuleIndex.php
@@ -10,7 +10,16 @@ class SystemModuleIndex extends Sys {
 
 	
 	protected $pageTitle = 'Opoink Module List';
+
+	/**
+	 * \Of\ModManager\Module
+	 */
 	protected $_modManager;
+
+	/**
+	 * array list of modules
+	 */
+	protected $modules;
 
 	public function __construct(
 		\Of\Session\SystemSession $SystemSession,

--- a/Database/Entity.php
+++ b/Database/Entity.php
@@ -339,13 +339,15 @@ class Entity extends \Of\Std\DataObject {
             'data' => []
         ];
 
-        if($this->isInstance($data)){
-            $o['data'][] = $data->getData();
-        } else {
-            foreach ($data as $key => $value) {
-                $o['data'][] = $value->getData();
-            }
-        }
+		if($data){
+			if($this->isInstance($data)){
+				$o['data'][] = $data->getData();
+			} else {
+				foreach ($data as $key => $value) {
+					$o['data'][] = $value->getData();
+				}
+			}
+		}
         return $o;
     }
 }

--- a/Database/Entity.php
+++ b/Database/Entity.php
@@ -321,6 +321,10 @@ class Entity extends \Of\Std\DataObject {
         $pagination = $this->getPagination();
         $pagination->set($page, $count, $limit);
 
+		if($pagination->currentPage() > $pagination->total_pages()){
+			$pagination->set($pagination->total_pages(), $count, $limit);
+		}
+
         $select->offset($pagination->offset())
         ->limit($limit);
 

--- a/Functions/Functions.php
+++ b/Functions/Functions.php
@@ -27,6 +27,10 @@ function opoink_renderError(){
             $mode = $config['mode'];
         }
     }
+
+	if (PHP_SAPI === 'cli') {
+		$mode = \Of\Constants::MODE_PROD;
+	}
     
     header("HTTP/1.0 500 Internal Server Errors");
 	if($mode === \Of\Constants::MODE_DEV){
@@ -39,7 +43,7 @@ function opoink_renderError(){
 		$dir = new \Of\File\Dirmanager();
 		$logDir = ROOT . DS . 'Var' .DS . 'logs';
 		$dir->createDir($logDir);
-        $message = "Type: " . get_class( $e ) . "; Message: {$e->getMessage()}; File: {$e->getFile()}; Line: {$e->getLine()};";
+        $message = date('Y-m-d H:i:s') . " " . "Type: " . get_class( $e ) . "; Message: {$e->getMessage()}; File: {$e->getFile()}; Line: {$e->getLine()};";
         file_put_contents( $logDir . DS . "exceptions.log", $message . PHP_EOL, FILE_APPEND );
         echo "Error occurred, logs has more info.";
 	}


### PR DESCRIPTION
Global Functions
- opoink_renderError() add a condition to check if the request is coming from CLI then make the mode production to log the error instead of rendering HTML

Entity
- \Of\Database\Entity::getFinalResponse() if the current page is greater than the total page then use total page as the current page
- \Of\Database\Entity::getFinalResponse() Fix variable $data to handle a null result